### PR TITLE
Workspaces and refactor of build.rs to use generics, slices, and &strs...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@
 /node_modules/
 
 ro-engine/build/
-ro-engine/target
+**/target
 **/*.rs.bk
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,181 @@
+[[package]]
+name = "base-x"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "discard"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ro-engine"
+version = "0.1.0"
+dependencies = [
+ "stdweb 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "discard 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb-internal-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base-x 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum base-x 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f59103b47307f76e03bef1633aec7fa9e29bfb5aa6daf5a334f94233c71f6c1"
+"checksum discard 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9a9117502da3c5657cb8e2ca7ffcf52d659f00c78c5127d1ebadc2ebe76465be"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
+"checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
+"checksum proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b16749538926f394755373f0dfec0852d79b3bd512a5906ceaeb72ee64a4eaa0"
+"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
+"checksum serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "aa113e5fc4b008a626ba2bbd41330b56c9987d667f79f7b243e5a2d03d91ed1c"
+"checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
+"checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
+"checksum stdweb 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca58653e50575e81d2e4d74327404c0c666bb31277827cd190b2e8527606319"
+"checksum stdweb-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa46e9b38ea028a8a327ae6db35a486ace3eb834f5600bb3b6a71c0b6b1bd4b"
+"checksum stdweb-internal-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0bb3289dfd46bba44d80ed47a9b3d4c43bf6c1d7931b29e2fa86bd6697ccf59"
+"checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
+"checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "ro-engine",
+]

--- a/ro-engine/build.rs
+++ b/ro-engine/build.rs
@@ -1,9 +1,22 @@
-use std::process::Command;
 use std::env;
+use std::ffi::OsStr;
+use std::fmt::Debug;
+use std::process::Command;
 
-fn python(args: &Vec<String>) {
-    let status = Command::new("python3").args(args).status();
-    if !status.expect("Failed to execute python subprocess").success() {
+const GAME_SCRIPTS: [&str; 5] = [
+    "bt_game.py",
+    "bt_lab.py",
+    "bt_tutorial.py",
+    "bt_menu.py",
+    "bt_renderer.py",
+];
+
+fn python<S: AsRef<OsStr> + Debug>(args: &[S]) {
+    let status = Command::new("python3")
+        .args(args)
+        .status()
+        .expect("Failed to execute python subprocess");
+    if !status.success() {
         panic!("Error from Python process while running {:?}", args);
     }
 }
@@ -12,15 +25,10 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let original_dir = env::var("ORIGINAL_DIR").unwrap_or("../original".to_string());
 
-    python(&vec!["scripts/check-originals.py".to_string(),
-            original_dir.clone(), out_dir.clone()]);
+    python(&["scripts/check-originals.py", &original_dir, &out_dir]);
 
-    let game_scripts = [
-        "bt_game.py", "bt_lab.py", "bt_tutorial.py",
-        "bt_menu.py", "bt_renderer.py"
-    ];
-
-    for script in game_scripts.iter() {
-        python(&vec![format!("scripts/{}", script), out_dir.clone()]);
+    for script in GAME_SCRIPTS.iter() {
+        let script = format!("scripts/{}", script);
+        python(&[&script, &out_dir]);
     }
 }

--- a/ro-engine/build.rs
+++ b/ro-engine/build.rs
@@ -23,7 +23,7 @@ fn python<S: AsRef<OsStr> + Debug>(args: &[S]) {
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let original_dir = env::var("ORIGINAL_DIR").unwrap_or("../original".to_string());
+    let original_dir = env::var("ORIGINAL_DIR").unwrap_or_else(|_| "../original".to_string());
 
     python(&["scripts/check-originals.py", &original_dir, &out_dir]);
 


### PR DESCRIPTION
At the end of your last stream, you were trying to get the python function in `build.rs` to use generics and avoid heap allocation.  Here's a refactor that uses traits, slices, and `&str`s instead of `Vec`s and `String`s.  I also put the game scripts into a constant.

A good general rule of thumb in Rust is that whenever you want a function to borrow a `Vec<T>`, `String` or `Pathbuf`, you should have it take as an argument `&[T]`, `&str`, or `&Path`, respectively.  The latter are all just views into the underlying heap allocated buffers; so they're more flexible.  By taking `&[T]` as an argument, for example, instead of just being able to pass a `&Vec<T>`, you can also pass `&[T]`.  They both work. (The magic that makes this possible is the `Deref` trait, but that might be getting too far in the weeds).  Anyway, this is why you never see APIs in Rust taking `&String` as an argument to a function; it's because taking `&str` is better.

Also - `unwrap_or` is eagerly evaluated and since you're allocating a `String` with `unwrap_or("../originals".to_string())`, it's better instead to use `unwrap_or_else(|| "../originals".to_string())`, which is lazily evaluated.  That way the default string won't ever be created if the ORIGINAL_DIR environment variable actually exists.

Finally - I think you wanted to structure this project with several independent libraries.  Cargo has a neat feature for working with multiple rust crates called `workspaces`.  I added a top-level `Cargo.toml` that sets this up for you.  Here are the [docs](https://doc.rust-lang.org/book/second-edition/ch14-03-cargo-workspaces.html) on it.  If you want to build all Rust crates, just go to the top level directory and `cargo build`.  If you want to build just the ro-engine crate, for example, stay in the top-level directory and `cargo build -p ro-engine`.  Same logic applies to all other cargo commands.  You can delete the target folder in ro-engine as now all your build stuff will go into a target directory at the project root.  You can also call cargo-web from the top-level directory, but you'll have to specify the crate, e.g. `cargo web build -p ro-engine`.